### PR TITLE
在庫管理機能の実装

### DIFF
--- a/app/api/stock-alerts/route.ts
+++ b/app/api/stock-alerts/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+// GET /api/stock-alerts - 在庫アラート取得
+export async function GET() {
+  try {
+    const session = await auth()
+
+    if (!session) {
+      return NextResponse.json(
+        { error: '認証が必要です' },
+        { status: 401 }
+      )
+    }
+
+    // 在庫数が最小在庫レベル以下の商品を取得
+    const lowStockProducts = await prisma.product.findMany({
+      where: {
+        currentStock: {
+          lte: prisma.product.fields.minStockLevel,
+        },
+      },
+      include: {
+        category: true,
+      },
+      orderBy: {
+        currentStock: 'asc',
+      },
+    })
+
+    // 在庫なしと在庫少に分類
+    const outOfStock = lowStockProducts.filter((p) => p.currentStock === 0)
+    const lowStock = lowStockProducts.filter(
+      (p) => p.currentStock > 0 && p.currentStock <= p.minStockLevel
+    )
+
+    return NextResponse.json({
+      outOfStock,
+      lowStock,
+      total: lowStockProducts.length,
+    })
+  } catch (error) {
+    console.error('在庫アラート取得エラー:', error)
+    return NextResponse.json(
+      { error: '在庫アラートの取得に失敗しました' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/stock-transactions/route.ts
+++ b/app/api/stock-transactions/route.ts
@@ -1,0 +1,179 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { z } from 'zod'
+
+const stockTransactionSchema = z.object({
+  productId: z.string().min(1, '商品は必須です'),
+  type: z.enum(['IN', 'OUT'], { message: '取引タイプは必須です' }),
+  quantity: z.number().int().min(1, '数量は1以上である必要があります'),
+  reason: z.string().min(1, '理由は必須です'),
+})
+
+// GET /api/stock-transactions - 在庫取引一覧取得
+export async function GET(request: Request) {
+  try {
+    const session = await auth()
+
+    if (!session) {
+      return NextResponse.json(
+        { error: '認証が必要です' },
+        { status: 401 }
+      )
+    }
+
+    const { searchParams } = new URL(request.url)
+    const productId = searchParams.get('productId') || ''
+    const type = searchParams.get('type') || ''
+    const startDate = searchParams.get('startDate') || ''
+    const endDate = searchParams.get('endDate') || ''
+    const page = parseInt(searchParams.get('page') || '1')
+    const limit = parseInt(searchParams.get('limit') || '20')
+    const skip = (page - 1) * limit
+
+    const where: {
+      productId?: string
+      type?: 'IN' | 'OUT'
+      createdAt?: {
+        gte?: Date
+        lte?: Date
+      }
+    } = {}
+
+    if (productId) {
+      where.productId = productId
+    }
+
+    if (type && (type === 'IN' || type === 'OUT')) {
+      where.type = type
+    }
+
+    if (startDate || endDate) {
+      where.createdAt = {}
+      if (startDate) {
+        where.createdAt.gte = new Date(startDate)
+      }
+      if (endDate) {
+        where.createdAt.lte = new Date(endDate)
+      }
+    }
+
+    const [transactions, total] = await Promise.all([
+      prisma.stockTransaction.findMany({
+        where,
+        include: {
+          product: {
+            include: {
+              category: true,
+            },
+          },
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+        skip,
+        take: limit,
+      }),
+      prisma.stockTransaction.count({ where }),
+    ])
+
+    return NextResponse.json({
+      transactions,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    })
+  } catch (error) {
+    console.error('在庫取引一覧取得エラー:', error)
+    return NextResponse.json(
+      { error: '在庫取引一覧の取得に失敗しました' },
+      { status: 500 }
+    )
+  }
+}
+
+// POST /api/stock-transactions - 在庫取引登録
+export async function POST(request: Request) {
+  try {
+    const session = await auth()
+
+    if (!session) {
+      return NextResponse.json(
+        { error: '認証が必要です' },
+        { status: 401 }
+      )
+    }
+
+    const body = await request.json()
+    const data = stockTransactionSchema.parse(body)
+
+    // 商品の存在確認
+    const product = await prisma.product.findUnique({
+      where: { id: data.productId },
+    })
+
+    if (!product) {
+      return NextResponse.json(
+        { error: '商品が見つかりません' },
+        { status: 404 }
+      )
+    }
+
+    // 出庫の場合、在庫数をチェック
+    if (data.type === 'OUT' && product.currentStock < data.quantity) {
+      return NextResponse.json(
+        { error: '在庫数が不足しています' },
+        { status: 400 }
+      )
+    }
+
+    // トランザクションで在庫取引と在庫数を更新
+    const result = await prisma.$transaction(async (tx) => {
+      // 在庫取引を作成
+      const transaction = await tx.stockTransaction.create({
+        data: {
+          productId: data.productId,
+          type: data.type,
+          quantity: data.quantity,
+          reason: data.reason,
+          userId: session.user.id,
+        },
+        include: {
+          product: {
+            include: {
+              category: true,
+            },
+          },
+        },
+      })
+
+      // 在庫数を更新
+      const newStock =
+        data.type === 'IN'
+          ? product.currentStock + data.quantity
+          : product.currentStock - data.quantity
+
+      await tx.product.update({
+        where: { id: data.productId },
+        data: { currentStock: newStock },
+      })
+
+      return transaction
+    })
+
+    return NextResponse.json(result, { status: 201 })
+  } catch (error) {
+    console.error('在庫取引登録エラー:', error)
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: error.issues[0].message },
+        { status: 400 }
+      )
+    }
+    return NextResponse.json(
+      { error: '在庫取引の登録に失敗しました' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/stock-transactions/new/page.tsx
+++ b/app/stock-transactions/new/page.tsx
@@ -1,0 +1,342 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { MainLayout, PageHeader } from '@/components/layout'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { toast } from 'sonner'
+import { ArrowLeft } from 'lucide-react'
+
+const stockTransactionSchema = z.object({
+  productId: z.string().min(1, '商品は必須です'),
+  type: z.enum(['IN', 'OUT']),
+  quantity: z.number().int().min(1, '数量は1以上である必要があります'),
+  reason: z.string().min(1, '理由は必須です'),
+})
+
+type StockTransactionFormData = z.infer<typeof stockTransactionSchema>
+
+interface Product {
+  id: string
+  name: string
+  sku: string
+  currentStock: number
+  category: {
+    id: string
+    name: string
+  }
+}
+
+export default function NewStockTransactionPage() {
+  const router = useRouter()
+  const [products, setProducts] = useState<Product[]>([])
+  const [loading, setLoading] = useState(false)
+  const [transactionType, setTransactionType] = useState<'IN' | 'OUT'>('IN')
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    reset,
+    formState: { errors },
+  } = useForm<StockTransactionFormData>({
+    resolver: zodResolver(stockTransactionSchema),
+    defaultValues: {
+      type: 'IN',
+    },
+  })
+
+  const productId = watch('productId')
+  const selectedProduct = products.find((p) => p.id === productId)
+
+  useEffect(() => {
+    fetchProducts()
+  }, [])
+
+  useEffect(() => {
+    setValue('type', transactionType)
+  }, [transactionType, setValue])
+
+  const fetchProducts = async () => {
+    try {
+      const response = await fetch('/api/products?limit=1000')
+      if (!response.ok) {
+        throw new Error('商品の取得に失敗しました')
+      }
+      const data = await response.json()
+      setProducts(data.products)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '商品の取得に失敗しました')
+    }
+  }
+
+  const onSubmit = async (data: StockTransactionFormData) => {
+    try {
+      setLoading(true)
+      const response = await fetch('/api/stock-transactions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || '在庫取引の登録に失敗しました')
+      }
+
+      toast.success('在庫取引を登録しました')
+      router.push('/stock-transactions')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '在庫取引の登録に失敗しました')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <MainLayout>
+      <PageHeader
+        title="在庫取引登録"
+        description="入庫・出庫を登録します"
+      />
+
+      <div className="max-w-2xl">
+        <Button
+          variant="ghost"
+          onClick={() => router.push('/stock-transactions')}
+          className="mb-4"
+        >
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          在庫取引履歴に戻る
+        </Button>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>取引情報</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Tabs value={transactionType} onValueChange={(v) => setTransactionType(v as 'IN' | 'OUT')}>
+              <TabsList className="grid w-full grid-cols-2 mb-6">
+                <TabsTrigger value="IN">入庫</TabsTrigger>
+                <TabsTrigger value="OUT">出庫</TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="IN">
+                <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+                  <div className="space-y-2">
+                    <Label htmlFor="productId">
+                      商品 <span className="text-red-500">*</span>
+                    </Label>
+                    <Select
+                      value={productId}
+                      onValueChange={(value) => setValue('productId', value)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="商品を選択" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {products.map((product) => (
+                          <SelectItem key={product.id} value={product.id}>
+                            {product.name} ({product.sku}) - 現在庫: {product.currentStock}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    {errors.productId && (
+                      <p className="text-sm text-red-500">{errors.productId.message}</p>
+                    )}
+                  </div>
+
+                  {selectedProduct && (
+                    <div className="p-4 bg-muted rounded-md">
+                      <div className="grid grid-cols-2 gap-2 text-sm">
+                        <div>
+                          <span className="text-muted-foreground">カテゴリー:</span>{' '}
+                          {selectedProduct.category.name}
+                        </div>
+                        <div>
+                          <span className="text-muted-foreground">現在庫:</span>{' '}
+                          {selectedProduct.currentStock}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="space-y-2">
+                    <Label htmlFor="quantity">
+                      入庫数量 <span className="text-red-500">*</span>
+                    </Label>
+                    <Input
+                      id="quantity"
+                      type="number"
+                      {...register('quantity', { valueAsNumber: true })}
+                      placeholder="例: 50"
+                    />
+                    {errors.quantity && (
+                      <p className="text-sm text-red-500">{errors.quantity.message}</p>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="reason">
+                      理由 <span className="text-red-500">*</span>
+                    </Label>
+                    <Select
+                      onValueChange={(value) => setValue('reason', value)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="理由を選択" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="仕入れ">仕入れ</SelectItem>
+                        <SelectItem value="返品受入">返品受入</SelectItem>
+                        <SelectItem value="調整増">調整増</SelectItem>
+                        <SelectItem value="その他">その他</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    {errors.reason && (
+                      <p className="text-sm text-red-500">{errors.reason.message}</p>
+                    )}
+                  </div>
+
+                  <div className="flex gap-4">
+                    <Button type="submit" disabled={loading}>
+                      {loading ? '登録中...' : '入庫登録'}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => router.push('/stock-transactions')}
+                      disabled={loading}
+                    >
+                      キャンセル
+                    </Button>
+                  </div>
+                </form>
+              </TabsContent>
+
+              <TabsContent value="OUT">
+                <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+                  <div className="space-y-2">
+                    <Label htmlFor="productId">
+                      商品 <span className="text-red-500">*</span>
+                    </Label>
+                    <Select
+                      value={productId}
+                      onValueChange={(value) => setValue('productId', value)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="商品を選択" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {products.map((product) => (
+                          <SelectItem key={product.id} value={product.id}>
+                            {product.name} ({product.sku}) - 現在庫: {product.currentStock}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    {errors.productId && (
+                      <p className="text-sm text-red-500">{errors.productId.message}</p>
+                    )}
+                  </div>
+
+                  {selectedProduct && (
+                    <div className="p-4 bg-muted rounded-md">
+                      <div className="grid grid-cols-2 gap-2 text-sm">
+                        <div>
+                          <span className="text-muted-foreground">カテゴリー:</span>{' '}
+                          {selectedProduct.category.name}
+                        </div>
+                        <div>
+                          <span className="text-muted-foreground">現在庫:</span>{' '}
+                          <span className={selectedProduct.currentStock === 0 ? 'text-red-500 font-medium' : ''}>
+                            {selectedProduct.currentStock}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="space-y-2">
+                    <Label htmlFor="quantity">
+                      出庫数量 <span className="text-red-500">*</span>
+                    </Label>
+                    <Input
+                      id="quantity"
+                      type="number"
+                      {...register('quantity', { valueAsNumber: true })}
+                      placeholder="例: 10"
+                    />
+                    {errors.quantity && (
+                      <p className="text-sm text-red-500">{errors.quantity.message}</p>
+                    )}
+                    {selectedProduct && (
+                      <p className="text-sm text-muted-foreground">
+                        ※ 現在庫: {selectedProduct.currentStock}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="reason">
+                      理由 <span className="text-red-500">*</span>
+                    </Label>
+                    <Select
+                      onValueChange={(value) => setValue('reason', value)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="理由を選択" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="販売">販売</SelectItem>
+                        <SelectItem value="返品">返品</SelectItem>
+                        <SelectItem value="調整減">調整減</SelectItem>
+                        <SelectItem value="廃棄">廃棄</SelectItem>
+                        <SelectItem value="その他">その他</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    {errors.reason && (
+                      <p className="text-sm text-red-500">{errors.reason.message}</p>
+                    )}
+                  </div>
+
+                  <div className="flex gap-4">
+                    <Button type="submit" disabled={loading}>
+                      {loading ? '登録中...' : '出庫登録'}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => router.push('/stock-transactions')}
+                      disabled={loading}
+                    >
+                      キャンセル
+                    </Button>
+                  </div>
+                </form>
+              </TabsContent>
+            </Tabs>
+          </CardContent>
+        </Card>
+      </div>
+    </MainLayout>
+  )
+}

--- a/app/stock-transactions/page.tsx
+++ b/app/stock-transactions/page.tsx
@@ -1,0 +1,288 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { MainLayout, PageHeader } from '@/components/layout'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Badge } from '@/components/ui/badge'
+import { Plus, ArrowUp, ArrowDown } from 'lucide-react'
+import { format } from 'date-fns'
+import { ja } from 'date-fns/locale'
+
+interface Product {
+  id: string
+  name: string
+  sku: string
+  category: {
+    id: string
+    name: string
+  }
+}
+
+interface StockTransaction {
+  id: string
+  type: 'IN' | 'OUT'
+  quantity: number
+  reason: string
+  createdAt: string
+  product: Product
+}
+
+interface TransactionsResponse {
+  transactions: StockTransaction[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+export default function StockTransactionsPage() {
+  const router = useRouter()
+  const [transactions, setTransactions] = useState<StockTransaction[]>([])
+  const [loading, setLoading] = useState(true)
+  const [selectedType, setSelectedType] = useState<string>('all')
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [currentPage, setCurrentPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+  const [total, setTotal] = useState(0)
+  const limit = 20
+
+  useEffect(() => {
+    fetchTransactions()
+  }, [currentPage, selectedType, startDate, endDate])
+
+  const fetchTransactions = async () => {
+    try {
+      setLoading(true)
+      const params = new URLSearchParams({
+        page: currentPage.toString(),
+        limit: limit.toString(),
+      })
+
+      if (selectedType && selectedType !== 'all') {
+        params.append('type', selectedType)
+      }
+
+      if (startDate) {
+        params.append('startDate', startDate)
+      }
+
+      if (endDate) {
+        params.append('endDate', endDate)
+      }
+
+      const response = await fetch(`/api/stock-transactions?${params}`)
+      if (!response.ok) {
+        throw new Error('在庫取引の取得に失敗しました')
+      }
+
+      const data: TransactionsResponse = await response.json()
+      setTransactions(data.transactions)
+      setTotal(data.total)
+      setTotalPages(data.totalPages)
+    } catch (error) {
+      console.error('在庫取引取得エラー:', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleTypeChange = (value: string) => {
+    setSelectedType(value)
+    setCurrentPage(1)
+  }
+
+  const handleDateFilter = () => {
+    setCurrentPage(1)
+    fetchTransactions()
+  }
+
+  const getTypeBadge = (type: 'IN' | 'OUT') => {
+    if (type === 'IN') {
+      return (
+        <Badge variant="outline" className="border-green-500 text-green-600">
+          <ArrowUp className="h-3 w-3 mr-1" />
+          入庫
+        </Badge>
+      )
+    }
+    return (
+      <Badge variant="outline" className="border-red-500 text-red-600">
+        <ArrowDown className="h-3 w-3 mr-1" />
+        出庫
+      </Badge>
+    )
+  }
+
+  return (
+    <MainLayout>
+      <PageHeader
+        title="在庫取引履歴"
+        description="入庫・出庫の履歴を確認します"
+      />
+
+      <div className="space-y-4">
+        {/* フィルター */}
+        <div className="flex flex-col sm:flex-row gap-4">
+          <Select value={selectedType} onValueChange={handleTypeChange}>
+            <SelectTrigger className="w-full sm:w-[200px]">
+              <SelectValue placeholder="取引タイプで絞り込み" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">すべての取引</SelectItem>
+              <SelectItem value="IN">入庫のみ</SelectItem>
+              <SelectItem value="OUT">出庫のみ</SelectItem>
+            </SelectContent>
+          </Select>
+
+          <div className="flex gap-2 flex-1">
+            <Input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              placeholder="開始日"
+            />
+            <Input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              placeholder="終了日"
+            />
+            <Button onClick={handleDateFilter} variant="outline">
+              絞り込み
+            </Button>
+          </div>
+
+          <Button onClick={() => router.push('/stock-transactions/new')}>
+            <Plus className="h-4 w-4 mr-2" />
+            新規登録
+          </Button>
+        </div>
+
+        {/* 取引テーブル */}
+        <div className="border rounded-lg">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>日時</TableHead>
+                <TableHead>取引タイプ</TableHead>
+                <TableHead>商品名</TableHead>
+                <TableHead>SKU</TableHead>
+                <TableHead>カテゴリー</TableHead>
+                <TableHead className="text-right">数量</TableHead>
+                <TableHead>理由</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {loading ? (
+                <TableRow>
+                  <TableCell colSpan={7} className="text-center py-8">
+                    読み込み中...
+                  </TableCell>
+                </TableRow>
+              ) : transactions.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={7} className="text-center py-8">
+                    在庫取引が見つかりませんでした
+                  </TableCell>
+                </TableRow>
+              ) : (
+                transactions.map((transaction) => (
+                  <TableRow key={transaction.id}>
+                    <TableCell>
+                      {format(new Date(transaction.createdAt), 'yyyy/MM/dd HH:mm', {
+                        locale: ja,
+                      })}
+                    </TableCell>
+                    <TableCell>{getTypeBadge(transaction.type)}</TableCell>
+                    <TableCell className="font-medium">
+                      {transaction.product.name}
+                    </TableCell>
+                    <TableCell className="font-mono text-sm">
+                      {transaction.product.sku}
+                    </TableCell>
+                    <TableCell>{transaction.product.category.name}</TableCell>
+                    <TableCell className="text-right font-medium">
+                      {transaction.type === 'IN' ? '+' : '-'}
+                      {transaction.quantity}
+                    </TableCell>
+                    <TableCell>{transaction.reason}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* ページネーション */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between">
+            <div className="text-sm text-muted-foreground">
+              全{total}件中 {(currentPage - 1) * limit + 1}〜
+              {Math.min(currentPage * limit, total)}件を表示
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+                disabled={currentPage === 1}
+              >
+                前へ
+              </Button>
+              <div className="flex items-center gap-2">
+                {Array.from({ length: Math.min(totalPages, 5) }, (_, i) => {
+                  let page
+                  if (totalPages <= 5) {
+                    page = i + 1
+                  } else if (currentPage <= 3) {
+                    page = i + 1
+                  } else if (currentPage >= totalPages - 2) {
+                    page = totalPages - 4 + i
+                  } else {
+                    page = currentPage - 2 + i
+                  }
+                  return (
+                    <Button
+                      key={page}
+                      variant={currentPage === page ? 'default' : 'outline'}
+                      size="sm"
+                      onClick={() => setCurrentPage(page)}
+                    >
+                      {page}
+                    </Button>
+                  )
+                })}
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setCurrentPage((prev) => Math.min(totalPages, prev + 1))}
+                disabled={currentPage === totalPages}
+              >
+                次へ
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </MainLayout>
+  )
+}


### PR DESCRIPTION
## 概要
Issue #7 の在庫管理機能を実装しました。

## 実装内容

### API Routes
- `GET /api/stock-transactions` - 在庫取引一覧取得
  - 取引タイプ（入庫/出庫）でフィルター
  - 日付範囲でフィルター
  - ページネーション対応
- `POST /api/stock-transactions` - 在庫取引登録
  - 入庫・出庫の登録
  - 在庫数の自動更新（トランザクション処理）
  - 出庫時の在庫数チェック
- `GET /api/stock-alerts` - 在庫アラート取得
  - 在庫なし商品の検出
  - 在庫少商品の検出（最小在庫レベル以下）

### ページ
- `/stock-transactions` - 在庫取引一覧ページ
  - 入庫・出庫履歴の表示
  - 取引タイプでフィルター
  - 日付範囲でフィルター
  - ページネーション（20件/ページ）
  - 取引タイプバッジ表示（入庫/出庫）
- `/stock-transactions/new` - 在庫取引登録ページ
  - タブで入庫・出庫を切り替え
  - 商品選択（現在庫表示）
  - 数量入力
  - 理由選択（プリセット + その他）
  - 出庫時の在庫数表示

### 技術的な実装
- Prismaトランザクションで在庫取引と在庫数を同時更新
- 出庫時の在庫不足チェック
- userIdを自動設定（セッションから取得）
- date-fnsで日時フォーマット

### 入庫理由
- 仕入れ
- 返品受入
- 調整増
- その他

### 出庫理由
- 販売
- 返品
- 調整減
- 廃棄
- その他

## 動作確認
- [ ] 在庫取引一覧の表示
- [ ] 取引タイプ・日付でのフィルター
- [ ] 入庫登録
- [ ] 出庫登録
- [ ] 在庫数の自動更新
- [ ] 出庫時の在庫不足チェック
- [ ] 在庫アラートの取得

## 関連Issue
Closes #7