### PR TITLE
fix: UI/UX改善（カテゴリー選択、SKU説明、バリデーション日本語化）

### DIFF
--- a/app/products/[id]/page.tsx
+++ b/app/products/[id]/page.tsx
@@ -54,6 +54,15 @@ export default function EditProductPage() {
     formState: { errors },
   } = useForm<ProductFormData>({
     resolver: zodResolver(productSchema),
+    defaultValues: {
+      name: '',
+      sku: '',
+      description: '',
+      categoryId: '',
+      price: 0,
+      currentStock: 0,
+      minStockLevel: 0,
+    },
   })
 
   const categoryId = watch('categoryId')
@@ -149,7 +158,7 @@ export default function EditProductPage() {
             <CardTitle>商品情報</CardTitle>
           </CardHeader>
           <CardContent>
-            <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+            <form onSubmit={handleSubmit(onSubmit)} className="space-y-6" noValidate>
               <div className="space-y-2">
                 <Label htmlFor="name">
                   商品名 <span className="text-red-500">*</span>
@@ -163,6 +172,9 @@ export default function EditProductPage() {
                   SKU <span className="text-red-500">*</span>
                 </Label>
                 <Input id="sku" {...register('sku')} placeholder="例: LAPTOP-001" />
+                <p className="text-sm text-muted-foreground">
+                  商品を識別するための一意のコード（例: LAPTOP-001、PHONE-XYZ-123）
+                </p>
                 {errors.sku && <p className="text-sm text-red-500">{errors.sku.message}</p>}
               </div>
 
@@ -183,7 +195,10 @@ export default function EditProductPage() {
                 <Label htmlFor="categoryId">
                   カテゴリー <span className="text-red-500">*</span>
                 </Label>
-                <Select value={categoryId} onValueChange={(value) => setValue('categoryId', value)}>
+                <Select
+                  value={categoryId}
+                  onValueChange={(value) => setValue('categoryId', value, { shouldValidate: true })}
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="カテゴリーを選択" />
                   </SelectTrigger>

--- a/app/products/new/page.tsx
+++ b/app/products/new/page.tsx
@@ -50,6 +50,15 @@ export default function NewProductPage() {
     formState: { errors },
   } = useForm<ProductFormData>({
     resolver: zodResolver(productSchema),
+    defaultValues: {
+      name: '',
+      sku: '',
+      description: '',
+      categoryId: '',
+      price: 0,
+      currentStock: 0,
+      minStockLevel: 0,
+    },
   })
 
   const categoryId = watch('categoryId')
@@ -111,7 +120,7 @@ export default function NewProductPage() {
             <CardTitle>商品情報</CardTitle>
           </CardHeader>
           <CardContent>
-            <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+            <form onSubmit={handleSubmit(onSubmit)} className="space-y-6" noValidate>
               <div className="space-y-2">
                 <Label htmlFor="name">
                   商品名 <span className="text-red-500">*</span>
@@ -125,6 +134,9 @@ export default function NewProductPage() {
                   SKU <span className="text-red-500">*</span>
                 </Label>
                 <Input id="sku" {...register('sku')} placeholder="例: LAPTOP-001" />
+                <p className="text-sm text-muted-foreground">
+                  商品を識別するための一意のコード（例: LAPTOP-001、PHONE-XYZ-123）
+                </p>
                 {errors.sku && <p className="text-sm text-red-500">{errors.sku.message}</p>}
               </div>
 
@@ -145,7 +157,10 @@ export default function NewProductPage() {
                 <Label htmlFor="categoryId">
                   カテゴリー <span className="text-red-500">*</span>
                 </Label>
-                <Select value={categoryId} onValueChange={(value) => setValue('categoryId', value)}>
+                <Select
+                  value={categoryId}
+                  onValueChange={(value) => setValue('categoryId', value, { shouldValidate: true })}
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="カテゴリーを選択" />
                   </SelectTrigger>


### PR DESCRIPTION
## 概要
商品登録・編集フォームのUI/UXを改善し、ユーザビリティを向上させました。

## 修正内容

### 1. カテゴリー選択の修正
**問題**: カテゴリーのドロップダウンが選択できない
**修正**: `setValue`に`{ shouldValidate: true }`オプションを追加

```typescript
<Select
  value={categoryId}
  onValueChange={(value) => setValue('categoryId', value, { shouldValidate: true })}
>
```

### 2. SKUフィールドの説明追加
**問題**: SKUが何かわからない
**修正**: ヘルプテキストを追加

```tsx
<p className="text-sm text-muted-foreground">
  商品を識別するための一意のコード（例: LAPTOP-001、PHONE-XYZ-123）
</p>
```

### 3. バリデーションメッセージの日本語化
**問題**: HTML5バリデーションにより英語のエラーメッセージが表示される
**修正**: 
- フォームに`noValidate`属性を追加してHTML5バリデーションを無効化
- `defaultValues`を設定してZodバリデーションを正常に動作させる
- Zodバリデーションのみを使用することで日本語エラーメッセージを確実に表示

```typescript
const { ... } = useForm<ProductFormData>({
  resolver: zodResolver(productSchema),
  defaultValues: {
    name: '',
    sku: '',
    description: '',
    categoryId: '',
    price: 0,
    currentStock: 0,
    minStockLevel: 0,
  },
})
```

```tsx
<form onSubmit={handleSubmit(onSubmit)} className="space-y-6" noValidate>
```

## 影響範囲
- `app/products/new/page.tsx` - 商品登録ページ
- `app/products/[id]/page.tsx` - 商品編集ページ

## テスト結果
```bash
✅ Lint: エラーなし
✅ Tests: 15/15 passed
```

## 関連Issue
Closes #25